### PR TITLE
Delegation of version management

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ To use this code:
     from ota import OTAUpdater
     from WIFI_CONFIG import SSID, PASSWORD
 
-    firmware_url = "https://raw.githubusercontent.com/<username>/<repo_name>/"
+    firmware_url = "https://raw.githubusercontent.com/<username>/<repo_name>/<branch_name>"
 
     ```
 
-    where `<username>` is your github username and `<repo_name>` is the name of the repository to check for updates.
+    where `<username>` is your github username, `<repo_name>` is the name of the repository to check for updates and `<branch_name>` is the name of the brnach to monitor.
 
 1. Add this to your main program code:
 
@@ -34,7 +34,7 @@ To use this code:
     ota_updater.download_and_install_update_if_available()
 
     ```
-1. On your GitHub repository, add a `version.json` file, and add a `version` element to the JSON file, with a version number:
+1. ~~On your GitHub repository, add a `version.json` file, and add a `version` element to the JSON file, with a version number:~~ ** It is not necessary to add the version file anymore as the versioning is based on the commit id, managed by GitHub. **
 
     ```json
     [
@@ -44,9 +44,9 @@ To use this code:
 
 ---
 
-The `OTAUpdater` will connect to github over wifi using your provided wifi credentials, check what the most up-to-date version of the firmware is, compare this to a local file present on the device named `version.json`, which contains the version number of the current on device firmware.
+The `OTAUpdater` will connect to github over wifi using your provided wifi credentials, check what the most up-to-date version of the firmware is, compare this to a local file present on the device named `version.json`, which contains the ~~version number~~ unique commit ID of the current on device firmware.
 
-If the local file is not present it will create one with a version number of `0`. If the Github verison is newer it will download the latest file and overwrite the file on the device with the same name, then restart the MicroPython board.
+If the local file is not present it will create one with a version number of `0`. If the Github version is newer, it will download the latest file and overwrite the file on the device with the same name, then restart the MicroPython board.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use this code:
 
     ```
 
-    where `<username>` is your github username, `<repo_name>` is the name of the repository to check for updates and `<branch_name>` is the name of the brnach to monitor.
+    where `<username>` is your github username, `<repo_name>` is the name of the repository to check for updates and `<branch_name>` is the name of the branch to monitor.
 
 1. Add this to your main program code:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use this code:
     ota_updater.download_and_install_update_if_available()
 
     ```
-1. ~~On your GitHub repository, add a `version.json` file, and add a `version` element to the JSON file, with a version number:~~ ** It is not necessary to add the version file anymore as the versioning is based on the commit id, managed by GitHub. **
+1. ~~On your GitHub repository, add a `version.json` file, and add a `version` element to the JSON file, with a version number:~~ **It is not necessary to add the version file anymore as the versioning is based on the commit id, managed by GitHub.**
 
     ```json
     [

--- a/ota.py
+++ b/ota.py
@@ -35,9 +35,10 @@ class OTAUpdater:
         # Necessary URL manipulations
         version_url = repo_url.replace("raw.githubusercontent.com", "github.com")  # Change the domain
         version_url = version_url.replace("/", "§", 4)                             # Temporary change for upcoming replace
-        version_url = version_url.replace("/", "latest-commit/", 1)                # Replacing for latest commit
+        version_url = version_url.replace("/", "/latest-commit/", 1)                # Replacing for latest commit
         version_url = version_url.replace("§", "/", 4)                             # Rollback Temporary change
         version_url = version_url + filename                                       # Add the targeted filename
+        
         return version_url
 
     def connect_wifi(self):
@@ -107,14 +108,12 @@ class OTAUpdater:
         self.connect_wifi()
 
         print('Checking for latest version...')
-        response = urequests.get(self.version_url)
+        headers = {"accept": "application/json"} 
+        response = urequests.get(self.version_url, headers=headers)
         
         data = json.loads(response.text)
        
-        # Turn list to dict using dictionary comprehension
-        my_dict = {data[i]: data[i + 1] for i in range(0, len(data), 2)}
-        
-        self.latest_version = my_dict['oid']  
+        self.latest_version = data['oid']                   # Access directly the id managed by GitHub
         print(f'latest version is: {self.latest_version}')
         
         # compare versions

--- a/ota.py
+++ b/ota.py
@@ -12,8 +12,10 @@ class OTAUpdater:
         self.ssid = ssid
         self.password = password
         self.repo_url = repo_url
-        self.version_url = repo_url + 'main/version.json'
-        self.firmware_url = repo_url + 'main/' + filename
+
+        # self.version_url = repo_url + 'main/version.json'                 # Replacement of the version mechanism by Github's oid
+        self.version_url = self.process_version_url(repo_url, filename)     # Process the new version url
+        self.firmware_url = repo_url + filename                             # Removal of the 'main' branch to allow different sources
 
         # get the current version (stored in version.json)
         if 'version.json' in os.listdir():    
@@ -22,11 +24,22 @@ class OTAUpdater:
             print(f"Current device firmware version is '{self.current_version}'")
 
         else:
-            self.current_version = 0
+            self.current_version = "0"
             # save the current version
             with open('version.json', 'w') as f:
                 json.dump({'version': self.current_version}, f)
             
+    def process_version_url(self, repo_url, filename):
+        """ Convert the file's url to its assoicatied version based on Github's oid management."""
+
+        # Necessary URL manipulations
+        version_url = repo_url.replace("raw.githubusercontent.com", "github.com")  # Change the domain
+        version_url = version_url.replace("/", "§", 4)                             # Temporary change for upcoming replace
+        version_url = version_url.replace("/", "latest-commit/", 1)                # Replacing for latest commit
+        version_url = version_url.replace("§", "/", 4)                             # Rollback Temporary change
+        version_url = version_url + filename                                       # Add the targeted filename
+        return version_url
+
     def connect_wifi(self):
         """ Connect to Wi-Fi."""
 
@@ -101,11 +114,11 @@ class OTAUpdater:
         # Turn list to dict using dictionary comprehension
         my_dict = {data[i]: data[i + 1] for i in range(0, len(data), 2)}
         
-        self.latest_version = my_dict['version']  
+        self.latest_version = my_dict['oid']  
         print(f'latest version is: {self.latest_version}')
         
         # compare versions
-        newer_version_available = True if self.current_version < self.latest_version else False
+        newer_version_available = True if self.current_version != self.latest_version else False
         
         print(f'Newer version available: {newer_version_available}')    
         return newer_version_available

--- a/test_ota.py
+++ b/test_ota.py
@@ -1,8 +1,8 @@
 from ota import OTAUpdater
 from WIFI_CONFIG import SSID, PASSWORD
 
-firmware_url = "https://raw.githubusercontent.com/kevinmcaleer/ota_test/"
+firmware_url = "https://raw.githubusercontent.com/pierreyvesbaloche/kevinmca_ota/main/"
 
-ota_updater = OTAUpdater(SSID, PASSWORD, firmware_url, "main.py")
+ota_updater = OTAUpdater(SSID, PASSWORD, firmware_url, "test_ota.py")
 
 ota_updater.download_and_install_update_if_available()


### PR DESCRIPTION
Hello Kevin,

First of all, thank you very much for this great projet that will certainly ease many Raspberry Pico users.

I wanted to suggest you the following through this PR : as people could be modifying their main file directly without changing the version on the tracking file, why not use directly GitHub's commit management to do so ? therefore, I slightly modified your version management to replace it with retrieving the object ID (oid) and use it as the new version code.

One file less to edit , that is always a plus :) .

I hope this will help the evolution of the project and thank you again for your great and inspiring projects.

Best regards.

Pierre-yves